### PR TITLE
[feature] Initial localization improvement

### DIFF
--- a/addons/tontoko_tileset/plugin.gd
+++ b/addons/tontoko_tileset/plugin.gd
@@ -4,9 +4,11 @@ extends EditorPlugin
 var tontoko_tileset
 var tontoko_tileset_path = "res://addons/tontoko_tileset/tontoko_tileset.tscn"
 var tontoko_tileset_save_path = "res://addons/tontoko_tileset/tontoko_tileset_save.tscn"
+var S # translation singleton
 
 func _enter_tree():
 	
+	S = load("res://addons/tontoko_tileset/tontoko_strings.gd").get_translation_singleton(self)
 	get_tree().set_meta("__editor_interface", get_editor_interface())
 	get_tree().set_meta("__undo_redo", get_undo_redo())
 	

--- a/addons/tontoko_tileset/tontoko_help.gd
+++ b/addons/tontoko_tileset/tontoko_help.gd
@@ -6,8 +6,11 @@ var tile_icon = preload("res://addons/tontoko_tileset/images/tile-24.svg")
 var image_icon = preload("res://addons/tontoko_tileset/images/image-24.svg")
 var canvas_icon = preload("res://addons/tontoko_tileset/images/empty-grid-24.svg")
 var mark_icon = preload("res://addons/tontoko_tileset/images/batu-grid-24.svg")
+var S
 
 func _ready():
+
+	S = load("res://addons/tontoko_tileset/tontoko_strings.gd").get_translation_singleton(self)
 	TranslationServer.set_locale(OS.get_locale())
 #	TranslationServer.set_locale("en")
 	$TabContainer.set_tab_icon(0,circle_icon)
@@ -16,34 +19,30 @@ func _ready():
 	$TabContainer.set_tab_icon(3,canvas_icon)
 	$TabContainer.set_tab_icon(4,mark_icon)
 #	print("使い方")
+	$TabContainer.set_tab_title(0,S.tr("Tutorial")) # 使い方
+	$TabContainer.set_tab_title(1,S.tr("Tile")) # タイル設定
+	$TabContainer.set_tab_title(2,S.tr("Image")) # 画像追加
+	$TabContainer.set_tab_title(3,S.tr("Canvas")) # キャンバス操作
+	$TabContainer.set_tab_title(4,S.tr("Buttons/Marks")) # ボタン・マーク説明
+
 	if TranslationServer.get_locale() == "ja_JP":
-		$TabContainer.set_tab_title(0,"使い方")
-		$TabContainer.set_tab_title(1,"タイル設定")
-		$TabContainer.set_tab_title(2,"画像追加")
-		$TabContainer.set_tab_title(3,"キャンバス操作")
-		$TabContainer.set_tab_title(4,"ボタン・マーク説明")
-		
+
 		$TabContainer/Tutorial/RichTextLabel.bbcode_text = read_bbcode("help_01_tutorial")
 		$TabContainer/Tile/RichTextLabel.bbcode_text = read_bbcode("help_02_tile")
 		$TabContainer/Image/RichTextLabel.bbcode_text = read_bbcode("help_03_image")
 		$TabContainer/Canvas/RichTextLabel.bbcode_text = read_bbcode("help_04_canvas")
 		$TabContainer/ButtonMark/RichTextLabel.bbcode_text = read_bbcode("help_05_buttons_marks")
-		
+
 	else:
-		$TabContainer.set_tab_title(0,"Tutorial")
-		$TabContainer.set_tab_title(1,"Tile")
-		$TabContainer.set_tab_title(2,"Image")
-		$TabContainer.set_tab_title(3,"Canvas")
-		$TabContainer.set_tab_title(4,"Buttons/Marks")
-		
+
 		$TabContainer/Tutorial/RichTextLabel.bbcode_text = read_bbcode("help_01_tutorial_en")
 		$TabContainer/Tile/RichTextLabel.bbcode_text = read_bbcode("help_02_tile_en")
 		$TabContainer/Image/RichTextLabel.bbcode_text = read_bbcode("help_03_image_en")
 		$TabContainer/Canvas/RichTextLabel.bbcode_text = read_bbcode("help_04_canvas_en")
 		$TabContainer/ButtonMark/RichTextLabel.bbcode_text = read_bbcode("help_05_buttons_marks_en")
-		
-		
-func read_bbcode(filepath) -> String: 
+
+
+func read_bbcode(filepath) -> String:
 	var file = File.new()
 	file.open("res://addons/tontoko_tileset/help/" + filepath + ".txt",File.READ)
 	var text = file.get_as_text()

--- a/addons/tontoko_tileset/tontoko_strings.csv
+++ b/addons/tontoko_tileset/tontoko_strings.csv
@@ -1,0 +1,18 @@
+,ja_JP
+Tutorial,使い方
+Tile,タイル設定
+Image,画像追加
+Canvas,キャンバス操作
+Buttons/Marks,ボタン・マーク説明
+TileSet,タイルセット
+Help,ヘルプ
+trout,マス
+px,px
+Normal Tile,通常タイル
+Auto WOLF 16px,オートタイル ウディタ 16px
+Auto WOLF 32px,オートタイル ウディタ 32px
+Auto WOLF 48px,オートタイル ウディタ 48px
+Auto RPGMaker 32px VX,オートタイル ツクール 32px VX
+Auto RPGMaker 48px MVMZ,オートタイル ツクール 48px MVMZ
+Pixel,ピクセル
+Cell,マス

--- a/addons/tontoko_tileset/tontoko_strings.gd
+++ b/addons/tontoko_tileset/tontoko_strings.gd
@@ -1,0 +1,81 @@
+## This class exists for the sole purpose of circunventing an apparent bug on TranslationServer where translations doesn't work at all in editor plugins
+## このクラスは、エディタープラグインで翻訳がまったく機能しないTranslationServerの明らかなバグを回避することを唯一の目的として存在します。
+## As soon as this bug on godot is fixed (or we realize that in fact we where doing something wrong all along) this class should be discarded and all "S.tr" strings in the project should be replaced by "tr"
+## godotのこのバグが修正されるとすぐに（または、実際に何か間違ったことをしていることに気づいたら）、このクラスを破棄し、プロジェクト内のすべての「S.tr」文字列を「tr」に置き換える必要があります。
+
+extends Node
+
+
+var strings_dict:Dictionary = {}
+
+
+func load_strings()->void:
+	## loads the strings dictionary from the default strings csv file
+	## デフォルトの文字列csvファイルから文字列辞書をロードします
+	var f:File = File.new()
+	f.open("res://addons/tontoko_tileset/tontoko_strings.csv", File.READ)
+	strings_dict = {} # replace previous dictionary
+	var header = Array(f.get_csv_line())
+	header[0] = "id"
+
+	while true: # loop csv lines
+		var line = f.get_csv_line()
+		if line.size() < 1 or (line.size() == 1 and line[0] == ""):
+			if f.eof_reached():
+				break
+			else:
+				continue
+
+		var count = -1
+		var id = line[0]
+		var subdict = {}
+		strings_dict[id] = subdict
+		for lang in header:
+			count += 1
+			if lang == "id":
+				continue
+			subdict[lang] = line[count]
+
+
+func tr(id:String)->String:
+	## shorthand for the translate method
+	## mimics the behavior of Object.tr(message:String)
+	## translateメソッドの省略形
+	## Object.tr(message:String) の動作を模倣します
+	return translate(id)
+
+
+func translate(id:String)->String:
+	## mimics the behavior of TranslationServer.translate(message:String)
+	## TranslationServer.translate(message:String) の動作を模倣します
+	if not strings_dict is Dictionary or strings_dict.size() < 1:
+		print("warning: strings not yet loaded")
+		load_strings()
+
+	if not id in strings_dict:
+		print("warning: there is no id '%s' in the strings dictionary" % id)
+		return id
+
+	var translations:Dictionary = strings_dict[id]
+	var locale:String = TranslationServer.get_locale()
+	if not locale in translations:
+		print("warning: there is no locale '%s' for id '%s'" % [locale, id])
+		return id
+
+	var trans:String = translations[locale]
+	print("id '%s' sucessfully translated on locale '%s' to '%s'" % [id, locale, trans])
+	return trans
+
+
+static func get_translation_singleton(node:Node, add_child_deferred:bool=true)->Node:
+	var S = node.get_node_or_null("/root/S")
+	if S:
+		return S
+
+	S = load("res://addons/tontoko_tileset/tontoko_strings.gd").new()
+	S.name = "S"
+	if add_child_deferred: # create a singleton to be used by the plugin
+		node.get_tree().root.call_deferred('add_child', S, true)
+	else:
+		node.get_tree().root.add_child(S, true) # create a singleton to be used by the plugin
+	return S


### PR DESCRIPTION
This pull request intends to make it easier to translate this plugin to other languages.

Godot already has a built-in translation feature, where you can use translation resource generated from csv files. You can add new translations at runtime with ```TranslationServer.add_translation()```

https://docs.godotengine.org/en/stable/classes/class_translationserver.html#class-translationserver-method-add-translation

and you can translate strings at runtime using ```TranslationServer.translate()```

https://docs.godotengine.org/en/stable/classes/class_translationserver.html#class-translationserver-method-translate

There's also a ```tr()``` method in the Object class

https://docs.godotengine.org/en/stable/classes/class_object.html#class-object-method-tr

that is just a shorthand for TranslationServer.translate() and makes it convenient to translate strings on any script, since every script inherits from Object.

But, while trying to implement this on your plugin, I noticed that it just doesn't work on editor plugins the same way it work while running a game, which is probably a godot bug. I asked about it on the godot QA but got no answers yet.

https://godotengine.org/qa/133107/how-to-localize-editor-plugins

To circumvent this godot bug, I wrote a small utility class to mimic the behavior of ```TranslationServer.translate()```. In this pull request I have added a csv file with some strings (tontoko_strings.csv), the translation class (tontoko_strings.gd) and made a small change on tontoko_help.gd to show how the translation feature would be used.